### PR TITLE
Freeze versions

### DIFF
--- a/ci/pmysql-pipeline.yml
+++ b/ci/pmysql-pipeline.yml
@@ -33,6 +33,7 @@ resources:
     api_token: {{pivnet_api_token}}
     product_slug: p-mysql
     product_version: {{p-mysql-version}}
+    product_version: {{pmysql-runtime-version}}
 - name: concourse-deploy-p-mysql
   type: git
   check_every: 4h
@@ -45,6 +46,7 @@ resources:
   source:
     user: enaml-ops
     repository: omg-cli
+
 - name: omg-product-bundle
   type: github-release
   check_every: 4h
@@ -81,10 +83,14 @@ jobs:
         trigger: true
       - get: concourse-deploy-p-mysql
       - get: omg-cli
+        version: &omg-cli-version
+          tag: {{omg-cli-version}}
         params:
           globs:
           - omg-linux
       - get: omg-product-bundle
+        version: &omg-product-bundle-version
+          tag: {{omg-product-bundle-version}}
         params:
           globs:
           - p-mysql-plugin-linux
@@ -116,10 +122,12 @@ jobs:
     - aggregate:
       - get: concourse-deploy-p-mysql
       - get: omg-cli
+        version: *omg-cli-version
         params:
           globs:
           - omg-linux
       - get: omg-product-bundle
+        version: *omg-product-bundle-version
         trigger: true
         params:
           globs:
@@ -172,6 +180,7 @@ jobs:
           globs:
           - omg-linux
       - get: omg-product-bundle
+        version: *omg-product-bundle-version
         passed: [get-product-version]
         trigger: true
         params:

--- a/pipeline-vars-template.yml
+++ b/pipeline-vars-template.yml
@@ -28,7 +28,9 @@ concourse-url: http://10.0.0.31:8080
 concourse-user: USERNAME
 concourse-pass: PASSWORD
 deployment-name: staging
-elastic-runtime-version: 1.7.15
+pmysql-runtime-version: 1.7.15
+omg-cli-version: v1.0.3
+omg-product-bundle-version: v1.0.7
 skip-haproxy: false
 slack-channel: '#ops'
 slack-username: ops-user

--- a/pipeline-vars-template.yml
+++ b/pipeline-vars-template.yml
@@ -30,7 +30,7 @@ concourse-pass: PASSWORD
 deployment-name: staging
 p-mysql-version: 1.7.12
 omg-cli-version: v1.0.3
-omg-product-bundle-version: v1.0.7
+omg-product-bundle-version: v1.0.7-484e6c
 skip-haproxy: false
 slack-channel: '#ops'
 slack-username: ops-user

--- a/pipeline-vars-template.yml
+++ b/pipeline-vars-template.yml
@@ -32,6 +32,9 @@ p-mysql-version: 1.7.12
 omg-cli-version: v1.0.3
 omg-product-bundle-version: v1.0.7
 skip-haproxy: false
+slack-channel: '#ops'
+slack-username: ops-user
+slack-icon-url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
 stemcell: bosh-vsphere-esxi-ubuntu-trusty-go_agent
 stemcell-cpi-glob: '*vsphere*'
 stemcell-version: 3232.17

--- a/pipeline-vars-template.yml
+++ b/pipeline-vars-template.yml
@@ -28,13 +28,10 @@ concourse-url: http://10.0.0.31:8080
 concourse-user: USERNAME
 concourse-pass: PASSWORD
 deployment-name: staging
-pmysql-runtime-version: 1.7.15
+p-mysql-version: 1.7.12
 omg-cli-version: v1.0.3
 omg-product-bundle-version: v1.0.7
 skip-haproxy: false
-slack-channel: '#ops'
-slack-username: ops-user
-slack-icon-url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
 stemcell: bosh-vsphere-esxi-ubuntu-trusty-go_agent
 stemcell-cpi-glob: '*vsphere*'
 stemcell-version: 3232.17


### PR DESCRIPTION
There is only small number of versions of `omg-product-bundle` and `p-mysql` PCF tile that can work together. You you try to use `1.7.15` or `1.7.22` version of `p-mysql` tile, you'll get the following error in `generate-manifest` task during a `deploy` job:
```
Error 100: Unable to render instance groups for deployment. Errors are:
   - Unable to render jobs for instance group 'monitoring-partition'. Errors are:
     - Unable to render templates for job 'replication-canary'. Errors are:
       - Error filling in template 'replication-canary.yml.erb' (line 4: Can't find property '["cf_mysql.external_host"]')
```

That's why I want versions to be freezed to particular combination in which we may be confident.